### PR TITLE
Clarify how to specify multiple arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Lazypipe assumes that all function parameters are static, gulp-if arguments need
 var gulpif = require('gulp-if');
 var jshint = require('gulp-jshint');
 var uglify = require('gulp-uglify');
+var concat = require('gulp-concat');
 
 var compressing = false;
 
@@ -88,6 +89,8 @@ var jsChannel = lazypipe()
   .pipe(jshint.reporter)
   // adding a step with an argument
   .pipe(jshint.reporter, 'fail')
+  // adding a step with multiple arguments
+  .pipe(concat, 'bundle.js', {newLine: ';'})
   // you can't say: .pipe(gulpif, compressing, uglify)
   // because uglify needs to be instantiated separately in each lazypipe instance
   // you can say this instead:
@@ -113,12 +116,12 @@ gulp.task('scripts', function () {
 
 Initializes a lazypipe.  Returns a function that can be used to create the pipeline.  The returned function has a function (`pipe`) which can be used to create new lazypipes with an additional step.
 
-### `lazypipe().pipe(fn, [args...])`
+### `lazypipe().pipe(fn[, arg1[, arg2[, ...]]])`
 
 Creates a new lazy pipeline with all the previous steps, and the new step added to the end.  Returns the new lazypipe.
 
 * `fn` - a stream creation function to call when the pipeline is created later.  You can either provide existing functions (such as gulp plugins), or provide your own custom functions if you want to manipulate the stream before creation.
-* `args` - Any remaining arguments are saved and passed into `fn` when the pipeline is created.
+* `arg1, arg2, ...` - Any remaining arguments are saved and passed into `fn` when the pipeline is created.
 
 The arguments allows you to pass in configuration arguments when the pipeline is created, like this:
 


### PR DESCRIPTION
Hey there!

I personally don't have this issue in my understanding but I have noticed my users do. [I keep seeing threads like this](https://discourse.roots.io/t/gulp-minifycss-and-css-special-comments/3428/1).

Let me know if this example is appropriate.

Thanks!

Edit:
Also I noticed that the MDN docs and elsewhere use this format for repeating arguments:

```js
fun.bind(thisArg[, arg1[, arg2[, ...]]])
```

rather than

```js
lazypipe().pipe(fn, [args...])
```

I have had people on my team comment that `[args...]` looks like a JS array. However I am used to seeing `[args...]` format from looking at man pages.
![screenshot 2015-04-07 13 04 23](https://cloud.githubusercontent.com/assets/2192970/7029961/c15c55ac-dd26-11e4-8980-d6cb6e3f5717.png)
